### PR TITLE
Add support for long tweets using Twitter threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ docker run -it --rm -p 5000:5000 qusasat:prod
 ### Heroku support
 The app supports [Heroku](https://www.heroku.com/) out of the box.
 Follow the instructions [here](https://devcenter.heroku.com/articles/container-registry-and-runtime)
-to deploy this web app using Docker.
+to deploy this web app using Heroku Container Registry.
+Another way, is to deploy by pushing the `master` branch to the `heroku` remote
+after configuring it. This is the standard and recommended way.
 
 ## Posting tweets
 
@@ -71,6 +73,14 @@ TWITTER_CONSUMER_SECRET=???
 TWITTER_ACCESS_KEY=???
 TWITTER_ACCESS_SECRET=???
 ```
+
+If you want to do a dry run (just print the tweets without posting them),
+add an environment variable to the `.env` file:
+```
+DRY_RUN=1
+```
+This is useful if you want to see how long tweets will be splitted into
+multiple tweets in a thread.
 
 On Heroku, you can supply those tokens using app
 [config vars](https://devcenter.heroku.com/articles/config-vars).

--- a/tweet_poster.py
+++ b/tweet_poster.py
@@ -5,7 +5,7 @@ import tweepy
 
 
 class TweetPoster():
-    def __init__(self, twitter_config, qusasat):
+    def __init__(self, twitter_config, qusasat, dry_run=False):
         self._qusasat = qusasat
         auth = tweepy.OAuthHandler(
             twitter_config['CONSUMER_KEY'],
@@ -16,23 +16,51 @@ class TweetPoster():
             twitter_config['ACCESS_SECRET']
         )
         self._api = tweepy.API(auth)
+        self._dry_run = dry_run
+        self._max_tweet_length = 280
+        self._ellipsis = u'\u2026'
 
     def post(self):
-        quote = self._get_suitable_quote()
-        formatted = self._format_quote(quote)
-        print('About to tweet:', formatted)
-        return self._api.update_status(status=formatted)
+        response_jsons = []
+        in_reply_to = None
+        long_quote = self._qusasat.get_random_quote()
+        for quote in self._split_quote(long_quote):
+            formatted = self._format_quote(quote)
+            print('About to tweet {} characters: {}'.format(len(formatted), formatted))
+            if not self._dry_run:
+                response = self._api.update_status(status=formatted,
+                                        in_reply_to_status_id=in_reply_to)
+                json = response._json
+            else:
+                json = {'id_str': '0'}
+            response_jsons.append(json)
+            in_reply_to = json['id_str']
+        return response_jsons
 
-    def _get_suitable_quote(self):
-        while True:
-            quote = self._qusasat.get_random_quote()
-            hashtag = self.to_hashtag(quote['category'])
-            if len(quote['quote']) + len(hashtag) + 1 < 280:
-                quote['hashtag'] = hashtag
-                return quote
+    def _split_quote(self, quote):
+        hashtag = self.to_hashtag(quote['category'])
+        quotes = []
+        current_quote = ""
+        max_length = self._max_tweet_length - len(self._ellipsis) * 2
+        remaining_length = max_length - len(hashtag) - len('\n')
+        for word in quote['quote'].split(): # no arguments split on whitespaces
+            spaced_word = ' ' + word if current_quote != "" else word
+            if len(spaced_word) < remaining_length:
+                current_quote = current_quote + spaced_word
+                remaining_length -= len(spaced_word)
+            else:
+                quotes.append({'quote': current_quote + self._ellipsis})
+                current_quote = self._ellipsis + word
+                remaining_length = max_length - len(current_quote)
+        quotes.append({'quote': current_quote})
+        quotes[0]['hashtag'] = hashtag
+        return quotes
 
     def _format_quote(self, quote):
-        return '{}\n{}'.format(quote['quote'], quote['hashtag'])
+        if quote.get('hashtag'):
+            return '{}\n{}'.format(quote['hashtag'], quote['quote'])
+        else:
+            return quote['quote']
 
     @classmethod
     def to_hashtag(cls, input_string):
@@ -48,6 +76,11 @@ if __name__ == '__main__':
         'ACCESS_KEY': env['TWITTER_ACCESS_KEY'],
         'ACCESS_SECRET': env['TWITTER_ACCESS_SECRET']
     }
-    poster = TweetPoster(twitter_config, qusasat)
-    response = poster.post()
-    print("Posted a tweet:", str(response))
+    dry_run = env.get('DRY_RUN') is not None
+    poster = TweetPoster(twitter_config, qusasat, dry_run=dry_run)
+    jsons = poster.post()
+    length = len(jsons)
+    tweet_s = 'tweet' if length == 1 else 'tweets'
+    print("Posted {} {}".format(length, tweet_s))
+    for idx, json in enumerate(jsons, 1):
+        print("Tweet {}: {}".format(idx, str(json)))

--- a/tweet_poster.py
+++ b/tweet_poster.py
@@ -42,7 +42,7 @@ class TweetPoster():
         quotes = []
         current_quote = ""
         max_length = self._max_tweet_length - len(self._ellipsis) * 2
-        remaining_length = max_length - len(hashtag) - len('\n')
+        remaining_length = max_length
         for word in quote['quote'].split(): # no arguments split on whitespaces
             spaced_word = ' ' + word if current_quote != "" else word
             if len(spaced_word) < remaining_length:
@@ -53,12 +53,44 @@ class TweetPoster():
                 current_quote = self._ellipsis + word
                 remaining_length = max_length - len(current_quote)
         quotes.append({'quote': current_quote})
-        quotes[0]['hashtag'] = hashtag
+        return self._append_hashtag(quotes, hashtag)
+
+    def _append_hashtag(self, quotes, hashtag):
+        if not quotes:
+            return quotes
+        last_quote_text = quotes[-1]['quote']
+        last_quote_length = len(last_quote_text) + len('\n') + len(hashtag)
+        # if last quote is too long, split it into 2 quotes
+        if last_quote_length > self._max_tweet_length:
+            words = last_quote_text.split()
+            quotes.append({})
+            return self._distribute_words(quotes, words, hashtag)
+        # else if last quote is too short, borrow the previous quote if any and split both into 2 quotes
+        elif len(quotes) > 1 and last_quote_length < self._max_tweet_length // 2:
+            # remove the ellipsis from the end of previous quote [:-1] and start of last quote [1:]
+            words = quotes[-2]['quote'][:-1].split() + last_quote_text[1:].split()
+            return self._distribute_words(quotes, words, hashtag)
+        # last quote is not too long or too short, or there is only 1 quote that can fit the hashtag
+        else:
+            quotes[-1]['hashtag'] = hashtag
         return quotes
+
+    def _distribute_words(self, quotes, words, hashtag):
+        # put the first half in the previous quote
+        quotes[-2]['quote'] = self._join_first_half(words) + self._ellipsis
+        # put the second half in the last quote with the hashtag
+        quotes[-1] = {'quote': self._ellipsis + self._join_second_half(words), 'hashtag': hashtag}
+        return quotes
+
+    def _join_first_half(self, words):
+        return ' '.join(words[:len(words)//2])
+
+    def _join_second_half(self, words):
+        return ' '.join(words[len(words)//2:])
 
     def _format_quote(self, quote):
         if quote.get('hashtag'):
-            return '{}\n{}'.format(quote['hashtag'], quote['quote'])
+            return '{}\n{}'.format(quote['quote'], quote['hashtag'])
         else:
             return quote['quote']
 

--- a/tweet_poster.py
+++ b/tweet_poster.py
@@ -43,22 +43,26 @@ class TweetPoster():
         current_quote = ""
         max_length = self._max_tweet_length - len(self._ellipsis) * 2
         remaining_length = max_length - len(hashtag) - len('\n')
-        for word in quote['quote'].split(): # no arguments split on whitespaces
-            spaced_word = ' ' + word if current_quote != "" else word
+        # we process the words in reverse order so that the first iteration
+        # (last quote) contains the hashtag where we can make room for it easily
+        # otherwise, we cannot easily identify the last tweet before running
+        # out of max length at which point the hashtag may not fit
+        for word in quote['quote'].split()[::-1]: # no arguments split on whitespaces
+            spaced_word = word + ' ' if current_quote != "" else word
             if len(spaced_word) < remaining_length:
-                current_quote = current_quote + spaced_word
+                current_quote = spaced_word + current_quote
                 remaining_length -= len(spaced_word)
             else:
-                quotes.append({'quote': current_quote + self._ellipsis})
-                current_quote = self._ellipsis + word
+                quotes.append({'quote': self._ellipsis + current_quote})
+                current_quote = word + self._ellipsis
                 remaining_length = max_length - len(current_quote)
         quotes.append({'quote': current_quote})
         quotes[0]['hashtag'] = hashtag
-        return quotes
+        return reversed(quotes) # reverse quotes to maintain the correct order again
 
     def _format_quote(self, quote):
         if quote.get('hashtag'):
-            return '{}\n{}'.format(quote['hashtag'], quote['quote'])
+            return '{}\n{}'.format(quote['quote'], quote['hashtag'])
         else:
             return quote['quote']
 

--- a/tweet_poster.py
+++ b/tweet_poster.py
@@ -43,26 +43,22 @@ class TweetPoster():
         current_quote = ""
         max_length = self._max_tweet_length - len(self._ellipsis) * 2
         remaining_length = max_length - len(hashtag) - len('\n')
-        # we process the words in reverse order so that the first iteration
-        # (last quote) contains the hashtag where we can make room for it easily
-        # otherwise, we cannot easily identify the last tweet before running
-        # out of max length at which point the hashtag may not fit
-        for word in quote['quote'].split()[::-1]: # no arguments split on whitespaces
-            spaced_word = word + ' ' if current_quote != "" else word
+        for word in quote['quote'].split(): # no arguments split on whitespaces
+            spaced_word = ' ' + word if current_quote != "" else word
             if len(spaced_word) < remaining_length:
-                current_quote = spaced_word + current_quote
+                current_quote = current_quote + spaced_word
                 remaining_length -= len(spaced_word)
             else:
-                quotes.append({'quote': self._ellipsis + current_quote})
-                current_quote = word + self._ellipsis
+                quotes.append({'quote': current_quote + self._ellipsis})
+                current_quote = self._ellipsis + word
                 remaining_length = max_length - len(current_quote)
         quotes.append({'quote': current_quote})
         quotes[0]['hashtag'] = hashtag
-        return reversed(quotes) # reverse quotes to maintain the correct order again
+        return quotes
 
     def _format_quote(self, quote):
         if quote.get('hashtag'):
-            return '{}\n{}'.format(quote['quote'], quote['hashtag'])
+            return '{}\n{}'.format(quote['hashtag'], quote['quote'])
         else:
             return quote['quote']
 


### PR DESCRIPTION
This PR adds the following:
- Now long quotes are not discarded, they are posted as multiple tweets in the same thread
- The category hashtag is still placed at the bottom of the last tweet
An example thread can be found [here](https://twitter.com/HammadyDev/status/1188471534207279105).

![image](https://user-images.githubusercontent.com/855847/67636706-5a233700-f8e4-11e9-8fa6-31e58c0b1c4c.png)

Note that in the above test tweet, the maximum was temporarily set to 40 rather than 280.